### PR TITLE
Update i18n dependency so Rails can be upgraded

### DIFF
--- a/faker.gemspec
+++ b/faker.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{Faker, a port of Data::Faker from Perl, is used to easily generate fake data: names, addresses, phone numbers, etc.}
   s.license     = 'MIT'
 
-  s.add_dependency('i18n', '~> 0.5')
+  s.add_dependency('i18n', '>= 1.6, < 2')
 
   s.files         = Dir['lib/**/*'] + %w(History.txt License.txt README.md)
   s.test_files    = Dir['{test,spec,features}/**/*']


### PR DESCRIPTION
This forked version of faker depends on `i18n ~> 0.5` and Rails 6.1.7 depends on `i18n >= 1.6, < 2` (through activesupport).

We can't upgrade rails in [the reach app](https://gitlab.webpt.com/prm/reach) from current 6.0.6 because of faker's i18n dependency so this is an update to `faker.gemspec` to bump the requirement of i18n to at least 1.6 so we can upgrade rails.